### PR TITLE
Add live version to web interface from git tags via Makefile (#61)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# Git Version (Tag or Commit-Hash)
+GIT_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+APP_VERSION ?= $(GIT_VERSION)
+export APP_VERSION
+
+# Variables
+DOCKER_COMPOSE = docker compose -f docker-compose.yml
+
+# Help (default target)
+.PHONY: help
+help:
+	@echo "ScanSync - Makefile Commands"
+	@echo "================================"
+	@echo ""
+	@echo "  Current version: $(GIT_VERSION)"
+	@echo ""
+	@echo "🚀 Production:"
+	@echo "  start         - Build and start all services"
+	@echo "  stop          - Stop all services"
+	@echo "  restart       - Restart all services"
+	@echo "  logs          - Show live logs"
+	@echo "  build         - Build all images"
+	@echo ""
+	@echo "🔧 General:"
+	@echo "  status        - Show the status of all containers"
+	@echo "  clean         - Stop all containers and remove unused images"
+	@echo "  clean-all     - Full cleanup (containers, images, volumes)"
+	@echo "  test          - Run the tests"
+	@echo ""
+
+# Production
+.PHONY: start
+start:
+	@echo "Starting ScanSync (Version: $(GIT_VERSION))..."
+	$(DOCKER_COMPOSE) up --build -d
+
+.PHONY: stop
+stop:
+	$(DOCKER_COMPOSE) down
+
+.PHONY: restart
+restart: stop start
+
+.PHONY: logs
+logs:
+	$(DOCKER_COMPOSE) logs -f
+
+.PHONY: build
+build:
+	@echo "Building ScanSync (Version: $(GIT_VERSION))..."
+	$(DOCKER_COMPOSE) build
+
+# General
+.PHONY: status
+status:
+	$(DOCKER_COMPOSE) ps
+
+.PHONY: clean
+clean:
+	$(DOCKER_COMPOSE) down --rmi local
+
+.PHONY: clean-all
+clean-all:
+	$(DOCKER_COMPOSE) down --rmi all -v
+
+.PHONY: test
+test:
+	./run-tests.sh

--- a/detection_service/Dockerfile
+++ b/detection_service/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.13-slim
 
 WORKDIR /app
 ENV TZ=Europe/Berlin
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 ENV CONFIG_PATH=/app/scansynclib/scansynclib/config.json
 COPY detection_service/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: web_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     ports:
       - 5001:5001
     environment:
@@ -29,6 +31,8 @@ services:
     build:
       context: .
       dockerfile: test_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     depends_on:
       - web-service
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:    
   smb_service:
-    build: ./smb_service
+    build:
+      context: ./smb_service
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     container_name: smb_service
     ports:
       - "137:137/udp"
@@ -17,6 +20,8 @@ services:
     build:
       context: .
       dockerfile: ocr_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     restart: unless-stopped
     volumes:
       - scans:/mnt/scans
@@ -35,6 +40,8 @@ services:
     build:
       context: .
       dockerfile: file_naming_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     restart: unless-stopped
     volumes:
       - scans:/mnt/scans
@@ -56,6 +63,8 @@ services:
     build:
       context: .
       dockerfile: detection_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     container_name: detection_service
     restart: unless-stopped
     volumes:
@@ -72,6 +81,8 @@ services:
     build:
       context: .
       dockerfile: metadata_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     restart: unless-stopped
     volumes:
       - scans:/mnt/scans
@@ -91,6 +102,8 @@ services:
     build:
       context: .
       dockerfile: upload_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     container_name: upload_service
     restart: unless-stopped
     volumes:
@@ -108,6 +121,8 @@ services:
     build:
       context: .
       dockerfile: web_service/Dockerfile
+      args:
+        - APP_VERSION=${APP_VERSION:-dev}
     ports:
       - 5001:5001
     extra_hosts:

--- a/file_naming_service/Dockerfile
+++ b/file_naming_service/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.13-slim
 
 WORKDIR /app
 ENV TZ=Europe/Berlin
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 ENV CONFIG_PATH=/app/scansynclib/scansynclib/config.json
 COPY file_naming_service/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/metadata_service/Dockerfile
+++ b/metadata_service/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.13-slim
 
 WORKDIR /app
 ENV TZ=Europe/Berlin
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 ENV CONFIG_PATH=/app/scansynclib/scansynclib/config.json
 COPY metadata_service/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/ocr_service/Dockerfile
+++ b/ocr_service/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.13-slim
 ENV TZ=Europe/Berlin
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 # Install ocrmypdf requirements
 RUN apt-get update && apt-get install -y \
     unpaper \

--- a/smb_service/Dockerfile
+++ b/smb_service/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:latest
 ENV TZ=Europe/Berlin
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 RUN apk add --no-cache samba samba-common-tools
 
 RUN adduser -D ocr && echo -e "ocr\nocr" | smbpasswd -a -s ocr && \

--- a/test_service/Dockerfile
+++ b/test_service/Dockerfile
@@ -1,6 +1,9 @@
 # Use the latest Seleniarm standalone Chromium image as the base image
 FROM seleniarm/standalone-chromium:latest
 
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
 # Switch to the root user to install dependencies
 USER root
 

--- a/upload_service/Dockerfile
+++ b/upload_service/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.13-slim
 
 WORKDIR /app
 ENV TZ=Europe/Berlin
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 ENV CONFIG_PATH=/app/scansynclib/scansynclib/config.json
 COPY upload_service/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/web_service/Dockerfile
+++ b/web_service/Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 5001
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
+# App version from build arg
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
 # For more info, please refer to https://aka.ms/vscode-docker-python-configure-containers
 RUN adduser --disabled-password --gecos "" appuser

--- a/web_service/src/main.py
+++ b/web_service/src/main.py
@@ -20,6 +20,7 @@ from scansynclib.onedrive_api import is_token_expired
 from scansynclib.config import config
 
 logger.info("Starting web service...")
+logger.info(f"App version: {os.environ.get('APP_VERSION') or config.get('version', 'Unknown')}")
 
 app = Flask(__name__)
 app.secret_key = os.urandom(24)
@@ -168,7 +169,7 @@ def inject_config():
 
     return dict(
         failed_document_count=failed_document_count,
-        version=config.get("version", "Unknown"),
+        version=os.environ.get("APP_VERSION") or config.get("version", "Unknown"),
         onedrive_token_error=is_token_expired(),
     )
 


### PR DESCRIPTION
* Initial plan

* Add dynamic version from git tags via Makefile and Docker build args

- Create Makefile that reads git tag version via `git describe`
- Pass APP_VERSION as Docker build arg through docker-compose.yml
- Update all Dockerfiles to accept APP_VERSION build arg and set as env var
- Read APP_VERSION env var in web service instead of hard-coded config value
- Log app version at web service boot
- Fall back to config.json version if env var not set

Agent-Logs-Url: https://github.com/maxi07/ScanSync/sessions/1ae7444f-19ab-4386-b174-a6292ff5885d



* Fix review comments: APP_VERSION override, fallback logic, smb/test service build args

---------